### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,8 +16,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+    - uses: actions/checkout@v4.2.2
+    - uses: astral-sh/setup-uv@v6.1.0
     - name: Set up Python
       run: |
         uv venv
@@ -51,10 +51,10 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0  # needed to get version
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@v6.1.0
     - name: Build
       run: |
         uv build

--- a/.github/workflows/updater-ga.yaml
+++ b/.github/workflows/updater-ga.yaml
@@ -12,7 +12,7 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
       with:
         token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/updater-precommit.yaml
+++ b/.github/workflows/updater-precommit.yaml
@@ -12,13 +12,13 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-python@v5.6.0
     - name: Install setuptools
       run: |
         pip install --upgrade setuptools
-    - uses: browniebroke/pre-commit-autoupdate-action@deb83bfe0036e1116ee4e241d6220274d69b1f9e   # v1.0.0
-    - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e   # v7.0.8
+    - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0   # v1.0.0
+    - uses: peter-evans/create-pull-request@v7.0.8   # v7.0.8
       if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.8](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.8)** on 2025-03-04T10:35:28Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)** on 2025-04-24T02:50:16Z
* **[browniebroke/pre-commit-autoupdate-action](https://github.com/browniebroke/pre-commit-autoupdate-action)** published a new release **[v1.0.0](https://github.com/browniebroke/pre-commit-autoupdate-action/releases/tag/v1.0.0)** on 2021-01-05T18:06:01Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.1.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.1.0)** on 2025-05-23T07:58:00Z
