### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/updater-precommit.yaml
+++ b/.github/workflows/updater-precommit.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: browniebroke/github-actions/.github/workflows/pre-commit-autoupdate.yml@v1
+    uses: browniebroke/github-actions/.github/workflows/pre-commit-autoupdate.yml@v1.17.0
     secrets:
       gh_pat: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[browniebroke/github-actions](https://github.com/browniebroke/github-actions)** published a new release **[v1.17.0](https://github.com/browniebroke/github-actions/releases/tag/v1.17.0)** on 2024-12-20T11:06:37Z
