### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.2.2
-    - uses: astral-sh/setup-uv@v6.1.0
+    - uses: astral-sh/setup-uv@v6.3.0
     - name: Set up Python
       run: |
         uv venv
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0  # needed to get version
-    - uses: astral-sh/setup-uv@v6.1.0
+    - uses: astral-sh/setup-uv@v6.3.0
     - name: Build
       run: |
         uv build


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.3.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.3.0)** on 2025-06-19T19:24:30Z
